### PR TITLE
Add context menu only once (on installed)

### DIFF
--- a/src/app/js/background.js
+++ b/src/app/js/background.js
@@ -386,11 +386,14 @@ chrome.runtime.onMessage.addListener(
 /**
  * Handle request from context menu (right click menu)
  * **/
-chrome.contextMenus.create({
-    id: "FAIR-biomed-context",
-    title: "FAIR-biomed search",
-    contexts: ["selection", "page"]
+chrome.runtime.onInstalled.addListener(function(details) {
+    chrome.contextMenus.create({
+        id: "FAIR-biomed-context",
+        title: "FAIR-biomed search",
+        contexts: ["selection", "page"]
+    });
 });
+
 chrome.contextMenus.onClicked.addListener(function(itemData) {
     let itemId = itemData.menuItemId;
     if (itemId === "FAIR-biomed" || itemId === "FAIR-biomed-context") {


### PR DESCRIPTION
Fix annoying 'Unchecked runtime.lastError: Cannot create item with duplicate id FAIR-biomed-context' error message in web-console due to attempts to add a already existing context menu on reinstall.