### PR TITLE
Plugin can request permissions, e.g. to allow CORS

### DIFF
--- a/library/clingen/clingen.registry.js
+++ b/library/clingen/clingen.registry.js
@@ -16,8 +16,10 @@ module.exports = new function() {
     this.info = 'clingen-info.html';
 
     // urls
-    let registry = 'http://reg.test.genome.network/alleles?name=';
+    let api_base = 'http://reg.test.genome.network/alleles';
+    let registry = api_base + '?name=';
     let genboree = 'http://reg.clinicalgenome.org/redmine/projects/registry/genboree_registry/';
+    this.permissions = [api_base];
 
     /** signal whether or not plugin can process a query **/
     this.claim = function(query) {

--- a/library/clingen/clingen.registry.js
+++ b/library/clingen/clingen.registry.js
@@ -19,7 +19,7 @@ module.exports = new function() {
     let api_base = 'http://reg.test.genome.network/alleles';
     let registry = api_base + '?name=';
     let genboree = 'http://reg.clinicalgenome.org/redmine/projects/registry/genboree_registry/';
-    this.permissions = [api_base];
+    this.endpoints = [api_base];
 
     /** signal whether or not plugin can process a query **/
     this.claim = function(query) {

--- a/library/ebi/chembl/chembl.image.js
+++ b/library/ebi/chembl/chembl.image.js
@@ -15,7 +15,11 @@ module.exports = new function() {
     this.logo = 'ChEMBL_clear.png';
     this.info = "chembl-info.html";
 
-    let chembl = "https://www.ebi.ac.uk/chembl/"
+    let chembl = "https://www.ebi.ac.uk/chembl/";
+    this.permissions = [
+        chembl + "api/data/image/*",
+        chembl + "glados-es/chembl_molecule/_search",
+    ];
 
     /** helper checks if a string is a valid id, e.g. CHEMBL25 **/
     this.isChemblId = function(query) {

--- a/library/ebi/chembl/chembl.image.js
+++ b/library/ebi/chembl/chembl.image.js
@@ -16,7 +16,7 @@ module.exports = new function() {
     this.info = "chembl-info.html";
 
     let chembl = "https://www.ebi.ac.uk/chembl/";
-    this.permissions = [
+    this.endpoints = [
         chembl + "api/data/image/*",
         chembl + "glados-es/chembl_molecule/_search",
     ];

--- a/library/ebi/gwas/ebi.gwas.js
+++ b/library/ebi/gwas/ebi.gwas.js
@@ -18,7 +18,7 @@ module.exports = new function() {
     let gwas = 'https://www.ebi.ac.uk/gwas/';
     let snp_api = 'rest/api/singleNucleotidePolymorphisms/';
     let snp_suffix = '/associations?projection=associationBySnp';
-    this.permissions = [gwas + snp_api + '*'];
+    this.endpoints = [gwas + snp_api + '*'];
 
     this.cleanQuery = function(query) {
         return query.trim().replace('-', '');

--- a/library/ebi/gwas/ebi.gwas.js
+++ b/library/ebi/gwas/ebi.gwas.js
@@ -18,6 +18,7 @@ module.exports = new function() {
     let gwas = 'https://www.ebi.ac.uk/gwas/';
     let snp_api = 'rest/api/singleNucleotidePolymorphisms/';
     let snp_suffix = '/associations?projection=associationBySnp';
+    this.permissions = [gwas + snp_api + '*'];
 
     this.cleanQuery = function(query) {
         return query.trim().replace('-', '');

--- a/library/ebi/identifiers/identifiers.collections.js
+++ b/library/ebi/identifiers/identifiers.collections.js
@@ -22,7 +22,7 @@ module.exports = new function() {
     // api urls
     let resolver = 'http://resolver.api.identifiers.org/';
     let idurl = "https://identifiers.org/";
-    this.permissions = [resolver + '*'];
+    this.endpoints = [resolver + '*'];
 
     /** signal whether or not plugin can process a query **/
     this.claim = function(query) {

--- a/library/ebi/identifiers/identifiers.collections.js
+++ b/library/ebi/identifiers/identifiers.collections.js
@@ -22,6 +22,7 @@ module.exports = new function() {
     // api urls
     let resolver = 'http://resolver.api.identifiers.org/';
     let idurl = "https://identifiers.org/";
+    this.permissions = [resolver + '*'];
 
     /** signal whether or not plugin can process a query **/
     this.claim = function(query) {

--- a/library/ebi/ols/ebi.ols.js
+++ b/library/ebi/ols/ebi.ols.js
@@ -16,6 +16,7 @@ module.exports = new function() {
     this.info = 'ebi.ols-info.html';
 
     let ols = 'https://www.ebi.ac.uk/ols/';
+    this.permissions = [ols + 'api/search'];
 
     /** signal whether or not plugin can process a query **/
     this.claim = function(query) {

--- a/library/ebi/ols/ebi.ols.js
+++ b/library/ebi/ols/ebi.ols.js
@@ -16,7 +16,7 @@ module.exports = new function() {
     this.info = 'ebi.ols-info.html';
 
     let ols = 'https://www.ebi.ac.uk/ols/';
-    this.permissions = [ols + 'api/search'];
+    this.endpoints = [ols + 'api/search'];
 
     /** signal whether or not plugin can process a query **/
     this.claim = function(query) {

--- a/library/europepmc/europepmc.articles.js
+++ b/library/europepmc/europepmc.articles.js
@@ -16,7 +16,9 @@ module.exports = new function() {
     this.info = 'europepmc-info.html';
 
     // parts of api urls
-    let pmc = 'https://www.ebi.ac.uk/europepmc/webservices/rest/search?query=';
+    let api_base = 'https://www.ebi.ac.uk/europepmc/webservices/rest/search';
+    let pmc = api_base + '?query=';
+    this.permissions = [api_base];
     let suffix = '&format=json&pageSize=8&resultType=lite';
     let item2link = function(x) {
         return 'https://europepmc.org/abstract/'+x['source']+'/'+x['id'];

--- a/library/europepmc/europepmc.articles.js
+++ b/library/europepmc/europepmc.articles.js
@@ -18,7 +18,7 @@ module.exports = new function() {
     // parts of api urls
     let api_base = 'https://www.ebi.ac.uk/europepmc/webservices/rest/search';
     let pmc = api_base + '?query=';
-    this.permissions = [api_base];
+    this.endpoints = [api_base];
     let suffix = '&format=json&pageSize=8&resultType=lite';
     let item2link = function(x) {
         return 'https://europepmc.org/abstract/'+x['source']+'/'+x['id'];

--- a/library/exac/exac.genes.in.region.js
+++ b/library/exac/exac.genes.in.region.js
@@ -12,7 +12,7 @@ module.exports = new function() {
     this.tags = ['human', 'genetics', 'genes'];
 
     let api_base = 'http://exac.hms.harvard.edu/rest/region/genes_in_region/';
-    this.permissions = [api_base + '*'];
+    this.endpoints = [api_base + '*'];
 
     /** accompanying resources **/
     this.logo = 'exac-screenshot-logo.png';

--- a/library/exac/exac.genes.in.region.js
+++ b/library/exac/exac.genes.in.region.js
@@ -11,6 +11,9 @@ module.exports = new function() {
     this.subtitle = 'Genes within genomic range';
     this.tags = ['human', 'genetics', 'genes'];
 
+    let api_base = 'http://exac.hms.harvard.edu/rest/region/genes_in_region/';
+    this.permissions = [api_base + '*'];
+
     /** accompanying resources **/
     this.logo = 'exac-screenshot-logo.png';
     this.info = 'exac-info.html';
@@ -59,8 +62,7 @@ module.exports = new function() {
 
     /** construct a url for an API call **/
     this.url = function(query, index) {
-        let api = 'http://exac.hms.harvard.edu/rest/region/genes_in_region/';
-        return api + this.q2string(query);
+        return api_base + this.q2string(query);
     };
 
     /** transform a raw result from an API call into a display object **/

--- a/library/exac/exac.variants.js
+++ b/library/exac/exac.variants.js
@@ -11,6 +11,9 @@ module.exports = new function() {
     this.subtitle = 'Variants in humans';
     this.tags = ['human', 'genetics', 'population'];
 
+    let api_base = 'http://exac.hms.harvard.edu/rest/variant/';
+    this.permissions = [api_base + '*'];
+
     /** accompanying resources **/
     this.logo = 'exac-screenshot-logo.png';
     this.info = 'exac-info.html';
@@ -47,8 +50,7 @@ module.exports = new function() {
 
     /** construct a url for an API call **/
     this.url = function(query, index) {
-        let api = 'http://exac.hms.harvard.edu/rest/variant/';
-        return api + q2string(query)
+        return api_base + q2string(query)
     };
 
     /** transform a raw result from an API call into a display object **/

--- a/library/exac/exac.variants.js
+++ b/library/exac/exac.variants.js
@@ -12,7 +12,7 @@ module.exports = new function() {
     this.tags = ['human', 'genetics', 'population'];
 
     let api_base = 'http://exac.hms.harvard.edu/rest/variant/';
-    this.permissions = [api_base + '*'];
+    this.endpoints = [api_base + '*'];
 
     /** accompanying resources **/
     this.logo = 'exac-screenshot-logo.png';

--- a/library/gel/panelapp.entities.js
+++ b/library/gel/panelapp.entities.js
@@ -14,7 +14,7 @@ module.exports = new function() {
 
     // urls for API and external pages
     let api_url = 'https://panelapp.genomicsengland.co.uk/api/v1/entities/';
-    this.permissions = [api_url + '*'];
+    this.endpoints = [api_url + '*'];
 
     // external page for panels
     let panels_url = 'https://panelapp.genomicsengland.co.uk/panels/';

--- a/library/gel/panelapp.entities.js
+++ b/library/gel/panelapp.entities.js
@@ -14,6 +14,8 @@ module.exports = new function() {
 
     // urls for API and external pages
     let api_url = 'https://panelapp.genomicsengland.co.uk/api/v1/entities/';
+    this.permissions = [api_url + '*'];
+
     // external page for panels
     let panels_url = 'https://panelapp.genomicsengland.co.uk/panels/';
     // eg. url for listing of all panels for gene:

--- a/library/genenames/hgnc.genes.js
+++ b/library/genenames/hgnc.genes.js
@@ -18,6 +18,8 @@ module.exports = new function() {
     // urls for API and external pages
     let search_url = 'http://rest.genenames.org/search/';
     let fetch_url = 'http://rest.genenames.org/fetch/hgnc_id/';
+    this.permissions = [search_url + '*', fetch_url + '*'];
+
     let www_url = 'https://www.genenames.org/';
     let report_url = www_url + 'data/gene-symbol-report/#!/hgnc_id/';
     // links to additional resources (used within the results data)

--- a/library/genenames/hgnc.genes.js
+++ b/library/genenames/hgnc.genes.js
@@ -18,7 +18,7 @@ module.exports = new function() {
     // urls for API and external pages
     let search_url = 'http://rest.genenames.org/search/';
     let fetch_url = 'http://rest.genenames.org/fetch/hgnc_id/';
-    this.permissions = [search_url + '*', fetch_url + '*'];
+    this.endpoints = [search_url + '*', fetch_url + '*'];
 
     let www_url = 'https://www.genenames.org/';
     let report_url = www_url + 'data/gene-symbol-report/#!/hgnc_id/';

--- a/library/hocomoco/hocomoco.search.js
+++ b/library/hocomoco/hocomoco.search.js
@@ -16,7 +16,7 @@ module.exports = new function() {
     // parts of api urls
     let api_base = 'http://hocomoco.autosome.ru/search.json';
     let url_prefix = api_base + '?detailed=true&arity=mono&query=';
-    this.permissions = [api_base];
+    this.endpoints = [api_base];
 
     let item2link = function(x) {
         return 'http://hocomoco.autosome.ru/motif/' + x['full_name'];

--- a/library/hocomoco/hocomoco.search.js
+++ b/library/hocomoco/hocomoco.search.js
@@ -13,9 +13,11 @@ module.exports = new function() {
     /** accompanying resources **/
     this.logo = 'hocomoco_logo.png';
     this.info = 'hocomoco-info.html';
-
     // parts of api urls
-    let url_prefix = 'http://hocomoco.autosome.ru/search.json?detailed=true&arity=mono&query=';
+    let api_base = 'http://hocomoco.autosome.ru/search.json';
+    let url_prefix = api_base + '?detailed=true&arity=mono&query=';
+    this.permissions = [api_base];
+
     let item2link = function(x) {
         return 'http://hocomoco.autosome.ru/motif/' + x['full_name'];
     };

--- a/library/impc/impc.models.js
+++ b/library/impc/impc.models.js
@@ -23,7 +23,7 @@ module.exports = new function() {
     let mousephenotype = 'https://www.mousephenotype.org/';
     let pd2_base = mousephenotype + 'data/phenodigm2/mousemodels';
     let pd2 = pd2_base + '?geneId=';
-    this.permissions = [solr_base, pd2_base];
+    this.endpoints = [solr_base, pd2_base];
 
     /** signal whether or not plugin can process a query **/
     this.claim = function(query) {

--- a/library/impc/impc.models.js
+++ b/library/impc/impc.models.js
@@ -16,11 +16,14 @@ module.exports = new function() {
     this.info = 'impc-info.html';
 
     // address of solr server for search queries
-    let solr= 'https://www.ebi.ac.uk/mi/impc/solr/phenodigm/select?q=';
+    let solr_base = 'https://www.ebi.ac.uk/mi/impc/solr/phenodigm/select';
+    let solr = solr_base + '?q=';
     let suffix = '&wt=json&fq=type:gene';
     // address for phenodigm2 query
     let mousephenotype = 'https://www.mousephenotype.org/';
-    let pd2 = mousephenotype + 'data/phenodigm2/mousemodels?geneId=';
+    let pd2_base = mousephenotype + 'data/phenodigm2/mousemodels';
+    let pd2 = pd2_base + '?geneId=';
+    this.permissions = [solr_base, pd2_base];
 
     /** signal whether or not plugin can process a query **/
     this.claim = function(query) {

--- a/library/jaspar/jaspar.search.js
+++ b/library/jaspar/jaspar.search.js
@@ -15,8 +15,11 @@ module.exports = new function() {
     this.info = 'jaspar-info.html';
 
     // parts of api urls
-    let jaspar = 'http://jaspar.genereg.net/api/v1/matrix/?search=';
+    let api_base = 'http://jaspar.genereg.net/api/v1/matrix/';
+    let jaspar = api_base + '?search=';
     let suffix = '&format=json&page_size=10&version=latest';
+    this.permissions = [api_base];
+
     let item2link = function(x) {
         return 'http://jaspar.genereg.net/matrix/'+x['matrix_id'];
     };

--- a/library/jaspar/jaspar.search.js
+++ b/library/jaspar/jaspar.search.js
@@ -18,7 +18,7 @@ module.exports = new function() {
     let api_base = 'http://jaspar.genereg.net/api/v1/matrix/';
     let jaspar = api_base + '?search=';
     let suffix = '&format=json&page_size=10&version=latest';
-    this.permissions = [api_base];
+    this.endpoints = [api_base];
 
     let item2link = function(x) {
         return 'http://jaspar.genereg.net/matrix/'+x['matrix_id'];

--- a/library/lncipedia/lncipedia.search.js
+++ b/library/lncipedia/lncipedia.search.js
@@ -15,7 +15,10 @@ module.exports = new function() {
     this.info = 'lncipedia-info.html';
 
     // parts of api urls
-    let lncipedia = 'https://lncipedia.org/api/search?id=';
+    let api_base = 'https://lncipedia.org/api/search';
+    let lncipedia = api_base + '?id=';
+    this.permissions = [api_base];
+
     let item2link = function(x) {
         return 'https://lncipedia.org/db/gene/'+x['lncipediaGeneID'];
     };

--- a/library/lncipedia/lncipedia.search.js
+++ b/library/lncipedia/lncipedia.search.js
@@ -17,7 +17,7 @@ module.exports = new function() {
     // parts of api urls
     let api_base = 'https://lncipedia.org/api/search';
     let lncipedia = api_base + '?id=';
-    this.permissions = [api_base];
+    this.endpoints = [api_base];
 
     let item2link = function(x) {
         return 'https://lncipedia.org/db/gene/'+x['lncipediaGeneID'];

--- a/library/marrvel/marrvel.human.js
+++ b/library/marrvel/marrvel.human.js
@@ -18,7 +18,7 @@ module.exports = new function() {
     // urls for API and external pages
     let api_base = 'http://marrvel.org/data/human';
     let api_url = api_base + '?geneSymbol=';
-    this.permissions = [api_base];
+    this.endpoints = [api_base];
 
     let gene_url = 'http://marrvel.org/search/gene/';
     let gtex_url = 'https://gtexportal.org/home/gene/';

--- a/library/marrvel/marrvel.human.js
+++ b/library/marrvel/marrvel.human.js
@@ -16,7 +16,10 @@ module.exports = new function() {
     this.info = 'marrvel-info.html';
 
     // urls for API and external pages
-    let api_url = 'http://marrvel.org/data/human?geneSymbol=';
+    let api_base = 'http://marrvel.org/data/human';
+    let api_url = api_base + '?geneSymbol=';
+    this.permissions = [api_base];
+
     let gene_url = 'http://marrvel.org/search/gene/';
     let gtex_url = 'https://gtexportal.org/home/gene/';
     let hgnc_url = 'https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/';

--- a/library/marrvel/marrvel.omim.js
+++ b/library/marrvel/marrvel.omim.js
@@ -16,7 +16,10 @@ module.exports = new function() {
     this.info = 'marrvel-info.html';
 
     // urls for API and external pages
-    let api_url = 'http://marrvel.org/data/OMIM?geneSymbol=';
+    let api_base = 'http://marrvel.org/data/OMIM';
+    let api_url = api_base + '?geneSymbol=';
+    this.permissions = [api_base];
+
     let gene_url = 'http://marrvel.org/search/gene/';
     let omim_url = 'https://www.omim.org/entry/';
 

--- a/library/marrvel/marrvel.omim.js
+++ b/library/marrvel/marrvel.omim.js
@@ -18,7 +18,7 @@ module.exports = new function() {
     // urls for API and external pages
     let api_base = 'http://marrvel.org/data/OMIM';
     let api_url = api_base + '?geneSymbol=';
-    this.permissions = [api_base];
+    this.endpoints = [api_base];
 
     let gene_url = 'http://marrvel.org/search/gene/';
     let omim_url = 'https://www.omim.org/entry/';

--- a/library/ncbi/clinvar/ncbi.clinvar.js
+++ b/library/ncbi/clinvar/ncbi.clinvar.js
@@ -19,6 +19,8 @@ module.exports = new function() {
     let clinvar = 'https://www.ncbi.nlm.nih.gov/clinvar/';
     let eutils = 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/';
     let suffix = '&db=clinvar&retmax=99999&format=json&sort=relevance&tool=FAIR-biomed&email=fair.ext@gmail.com';
+    this.permissions = [eutils + 'esearch.fcgi', eutils + 'esummary.fcgi'];
+
     let id2link = function(id) {
         return clinvar + 'variation/' + id
     };

--- a/library/ncbi/clinvar/ncbi.clinvar.js
+++ b/library/ncbi/clinvar/ncbi.clinvar.js
@@ -19,7 +19,7 @@ module.exports = new function() {
     let clinvar = 'https://www.ncbi.nlm.nih.gov/clinvar/';
     let eutils = 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/';
     let suffix = '&db=clinvar&retmax=99999&format=json&sort=relevance&tool=FAIR-biomed&email=fair.ext@gmail.com';
-    this.permissions = [eutils + 'esearch.fcgi', eutils + 'esummary.fcgi'];
+    this.endpoints = [eutils + 'esearch.fcgi', eutils + 'esummary.fcgi'];
 
     let id2link = function(id) {
         return clinvar + 'variation/' + id

--- a/library/ncbi/gene/ncbi.gene.js
+++ b/library/ncbi/gene/ncbi.gene.js
@@ -17,6 +17,8 @@ module.exports = new function() {
     // parts of api urls
     let eutils = 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/';
     let suffix = '&db=gene&retmax=5&format=json&sort=relevance&tool=FAIR-biomed&email=fair.ext@gmail.com';
+    this.permissions = [eutils + 'esearch.fcgi', eutils + 'esummary.fcgi'];
+
     let id2link = function(id) {
         return 'https://www.ncbi.nlm.nih.gov/gene/'+id
     };

--- a/library/ncbi/gene/ncbi.gene.js
+++ b/library/ncbi/gene/ncbi.gene.js
@@ -17,7 +17,7 @@ module.exports = new function() {
     // parts of api urls
     let eutils = 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/';
     let suffix = '&db=gene&retmax=5&format=json&sort=relevance&tool=FAIR-biomed&email=fair.ext@gmail.com';
-    this.permissions = [eutils + 'esearch.fcgi', eutils + 'esummary.fcgi'];
+    this.endpoints = [eutils + 'esearch.fcgi', eutils + 'esummary.fcgi'];
 
     let id2link = function(id) {
         return 'https://www.ncbi.nlm.nih.gov/gene/'+id

--- a/library/ncbi/pubmed/pubmed.search.js
+++ b/library/ncbi/pubmed/pubmed.search.js
@@ -18,7 +18,7 @@ module.exports = new function() {
     // parts of api urls
     let eutils = 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/';
     let suffix = '&db=pubmed&retmax=8&format=json&sort=relevance&tool=FAIR-biomed&email=fair.ext@gmail.com';
-    this.permissions = [eutils + 'esearch.fcgi', eutils + 'esummary.fcgi'];
+    this.endpoints = [eutils + 'esearch.fcgi', eutils + 'esummary.fcgi'];
 
     let id2link = function(id) {
         return 'https://www.ncbi.nlm.nih.gov/pubmed/'+id;

--- a/library/ncbi/pubmed/pubmed.search.js
+++ b/library/ncbi/pubmed/pubmed.search.js
@@ -18,6 +18,8 @@ module.exports = new function() {
     // parts of api urls
     let eutils = 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/';
     let suffix = '&db=pubmed&retmax=8&format=json&sort=relevance&tool=FAIR-biomed&email=fair.ext@gmail.com';
+    this.permissions = [eutils + 'esearch.fcgi', eutils + 'esummary.fcgi'];
+
     let id2link = function(id) {
         return 'https://www.ncbi.nlm.nih.gov/pubmed/'+id;
     };

--- a/library/reactome/reactome.pathways.js
+++ b/library/reactome/reactome.pathways.js
@@ -25,7 +25,7 @@ module.exports = new function() {
     let api = "ContentService/";
     // endpoints for first and second round queries
     let endpoints = ['search/query?query=', 'data/pathways/low/diagram/entity/'];
-    this.permissions = [
+    this.endpoints = [
         reactome + api + 'search/query',
         reactome + api + 'data/pathways/low/diagram/entity/*'
     ];

--- a/library/reactome/reactome.pathways.js
+++ b/library/reactome/reactome.pathways.js
@@ -25,6 +25,10 @@ module.exports = new function() {
     let api = "ContentService/";
     // endpoints for first and second round queries
     let endpoints = ['search/query?query=', 'data/pathways/low/diagram/entity/'];
+    this.permissions = [
+        reactome + api + 'search/query',
+        reactome + api + 'data/pathways/low/diagram/entity/*'
+    ];
     // connectors with the suffix for first and second round queries
     let joins = ['&', '?'];
     // the species must be written in words because the search query does not accept 9606

--- a/library/string/string.network.js
+++ b/library/string/string.network.js
@@ -11,6 +11,7 @@ module.exports = new function() {
     this.title = 'STRING DB';
     this.subtitle = 'Protein interaction network';
     this.tags = ['genes', 'proteins', 'ppi', 'network', 'human'];
+    this.permissions = [];
 
     /** accompanying resources **/
     this.logo = 'string-logo.png';

--- a/library/string/string.network.js
+++ b/library/string/string.network.js
@@ -11,7 +11,7 @@ module.exports = new function() {
     this.title = 'STRING DB';
     this.subtitle = 'Protein interaction network';
     this.tags = ['genes', 'proteins', 'ppi', 'network', 'human'];
-    this.permissions = [];
+    this.endpoints = [];
 
     /** accompanying resources **/
     this.logo = 'string-logo.png';

--- a/library/ucsc/ucsc.genomebrowser.js
+++ b/library/ucsc/ucsc.genomebrowser.js
@@ -11,7 +11,7 @@ module.exports = new function() {
     this.title = 'UCSC Genome Browser';
     this.subtitle = 'Viewer of genomic regions';
     this.tags = ['genome', 'tracks', 'annotations'];
-    this.permissions = [];
+    this.endpoints = [];
 
     /** accompanying resources **/
     this.logo = 'ucsc_genome_browser_logo.png';

--- a/library/ucsc/ucsc.genomebrowser.js
+++ b/library/ucsc/ucsc.genomebrowser.js
@@ -11,6 +11,7 @@ module.exports = new function() {
     this.title = 'UCSC Genome Browser';
     this.subtitle = 'Viewer of genomic regions';
     this.tags = ['genome', 'tracks', 'annotations'];
+    this.permissions = [];
 
     /** accompanying resources **/
     this.logo = 'ucsc_genome_browser_logo.png';

--- a/library/uniprot/uniprot.search.js
+++ b/library/uniprot/uniprot.search.js
@@ -16,6 +16,8 @@ module.exports = new function() {
     this.info = 'uniprot-info.html';
 
     let uniprot = 'https://www.uniprot.org/uniprot/';
+    this.permissions = [uniprot];
+
     let cols = ['id', 'entry%20name', 'protein%20names', 'genes', 'organism'];
 
     /** signal whether or not plugin can process a query **/

--- a/library/uniprot/uniprot.search.js
+++ b/library/uniprot/uniprot.search.js
@@ -16,7 +16,7 @@ module.exports = new function() {
     this.info = 'uniprot-info.html';
 
     let uniprot = 'https://www.uniprot.org/uniprot/';
-    this.permissions = [uniprot];
+    this.endpoints = [uniprot];
 
     let cols = ['id', 'entry%20name', 'protein%20names', 'genes', 'organism'];
 

--- a/library/wikimedia/wikipedia.js
+++ b/library/wikimedia/wikipedia.js
@@ -12,7 +12,7 @@ module.exports = new function() {
     this.tags = ['encyclopaedia'];
 
     let api_base = 'https://en.wikipedia.org/w/api.php';
-    this.permissions = [api_base];
+    this.endpoints = [api_base];
 
     /** accompanying resources **/
     this.logo = '103px-Wikipedia-logo-v2.svg.png';

--- a/library/wikimedia/wikipedia.js
+++ b/library/wikimedia/wikipedia.js
@@ -11,6 +11,9 @@ module.exports = new function() {
     this.subtitle = 'The free encyclopaedia';
     this.tags = ['encyclopaedia'];
 
+    let api_base = 'https://en.wikipedia.org/w/api.php';
+    this.permissions = [api_base];
+
     /** accompanying resources **/
     this.logo = '103px-Wikipedia-logo-v2.svg.png';
     this.info = 'wikipedia-info.html';
@@ -32,7 +35,7 @@ module.exports = new function() {
     this.url = function(query, index) {
         query = query.split(' ').join('%20');
         let url = null;
-        let api = 'https://en.wikipedia.org/w/api.php?action=';
+        let api = api_base + '?action=';
         let suffix = '&format=json&formatversion=2';
         if (index === 0 || typeof(index)==='undefined') {
             url = api + 'opensearch&search=' + query + suffix;

--- a/library/wikimedia/wiktionary.js
+++ b/library/wikimedia/wiktionary.js
@@ -11,6 +11,9 @@ module.exports = new function() {
     this.subtitle = 'The free dictionary';
     this.tags = ['dictionary'];
 
+    let api_base = 'https://en.wiktionary.org/w/api.php';
+    this.permissions = [api_base];
+
     /** accompanying resources **/
     this.logo = '99px-WiktionaryEn.svg.png';
     this.info = 'wiktionary-info.html';
@@ -30,7 +33,7 @@ module.exports = new function() {
     /** construct a url for an API call **/
     this.url = function(query) {
         query = query.split(' ').join('%20');
-        let url = 'https://en.wiktionary.org/w/api.php?action=query'
+        let url = api_base + '?action=query'
             +'&titles='+query+'&prop=extracts&format=json&formatversion=2'
         return url;
     };

--- a/library/wikimedia/wiktionary.js
+++ b/library/wikimedia/wiktionary.js
@@ -12,7 +12,7 @@ module.exports = new function() {
     this.tags = ['dictionary'];
 
     let api_base = 'https://en.wiktionary.org/w/api.php';
-    this.permissions = [api_base];
+    this.endpoints = [api_base];
 
     /** accompanying resources **/
     this.logo = '99px-WiktionaryEn.svg.png';

--- a/src/build/build-library.js
+++ b/src/build/build-library.js
@@ -64,18 +64,11 @@ console.log("Building library from: "+libdir);
 
 
 console.log("Reading plugin test status");
-let plugin_status = {};
-plugin_status_file = "library"+path.sep+"plugin_status";
-if (fs.existsSync(plugin_status_file)) {
-    fs.readFileSync(plugin_status_file)
-        .toString().split("\n")
-        .map(function(x) {
-            if (x!="") {
-                plugin_status[x] = true
-            }
-        })
-} else {
-    console.log("Plugin status file does not exist. Run tests before building library.");
+let plugin_status;
+try {
+    plugin_status = libraryloader.loadPluginStatuses(libdir + path.sep + "plugin_status");
+} catch (e) {
+    console.error(e);
     return;
 }
 

--- a/src/build/build-static.js
+++ b/src/build/build-static.js
@@ -33,7 +33,7 @@ let libdir = "library";
 libdir = path.resolve(libdir);
 let plugin_status = libraryloader.loadPluginStatuses(libdir + path.sep + "plugin_status");
 let plugins = libraryloader.load(libdir).filter((plugin) => plugin_status[plugin.id] === true);
-let plugin_permissions = plugins.map(plugin => plugin.permissions).filter((v) => v !== undefined).flat();
+let plugin_endpoints = plugins.map(plugin => plugin.endpoints).filter((v) => v !== undefined).flat();
 
 console.log("Preparing manifest");
 let npm_package = JSON.parse(fs.readFileSync("package.json").toString());
@@ -42,7 +42,7 @@ let manifest_file = ['dist', 'manifest.json'].join(path.sep);
 let manifest = manifest_template.replace("_version_", npm_package['version']);
 if (browser === "firefox") {
     let manifest_json = JSON.parse(manifest);
-    manifest_json.permissions = [...new Set([...manifest_json.permissions,...plugin_permissions])];
+    manifest_json.permissions = [...new Set([...manifest_json.permissions,...plugin_endpoints])];
     manifest = JSON.stringify(manifest_json);
 }
 fs.writeFileSync(manifest_file, manifest);

--- a/src/build/build-static.js
+++ b/src/build/build-static.js
@@ -8,6 +8,7 @@
 let path = require("path");
 let fs = require("fs-extra");
 let utf8 = require("utf8");
+let libraryloader = require("./library-loader");
 
 // detect build mode - development or production
 // This is specified by a command line positional argument
@@ -27,12 +28,23 @@ console.log("Preparing extension (" + browser+ ")");
 console.log("Setting up output directories");
 fs.ensureDirSync("dist");
 
+console.log("Load library infos")
+let libdir = "library";
+libdir = path.resolve(libdir);
+let plugin_status = libraryloader.loadPluginStatuses(libdir + path.sep + "plugin_status");
+let plugins = libraryloader.load(libdir).filter((plugin) => plugin_status[plugin.id] === true);
+let plugin_permissions = plugins.map(plugin => plugin.permissions).filter((v) => v !== undefined).flat();
 
 console.log("Preparing manifest");
 let npm_package = JSON.parse(fs.readFileSync("package.json").toString());
 let manifest_template = fs.readFileSync(__dirname+"/configurations/manifest-"+browser+".json").toString();
 let manifest_file = ['dist', 'manifest.json'].join(path.sep);
 let manifest = manifest_template.replace("_version_", npm_package['version']);
+if (browser === "firefox") {
+    let manifest_json = JSON.parse(manifest);
+    manifest_json.permissions = [...new Set([...manifest_json.permissions,...plugin_permissions])];
+    manifest = JSON.stringify(manifest_json);
+}
 fs.writeFileSync(manifest_file, manifest);
 
 

--- a/src/build/library-loader.js
+++ b/src/build/library-loader.js
@@ -83,10 +83,24 @@ function loadPlugins(dirpath) {
     return plugins;
 }
 
+function loadPluginStatuses(plugin_status_file) {
+    if (!fs.existsSync(plugin_status_file))
+        throw "Plugin status file does not exist. Run tests before building library.";
+    let plugin_status = {};
+    fs.readFileSync(plugin_status_file)
+        .toString().split("\n")
+        .map(function(x) {
+            if (x!="") {
+                plugin_status[x] = true
+            }
+        });
+    return plugin_status;
+}
 
 module.exports = new function() {
     this.load = function(dirpath) {
         return loadPlugins(dirpath);
     };
+    this.loadPluginStatuses = loadPluginStatuses;
 }();
 


### PR DESCRIPTION
In Firefox an extension can't make CORS requests. It led to problems with some API-s (which doesn't set CORS headers) in firefox which could neither generate a preview nor allowed to show an external link.

Now a plugin can inform manifest to add permissions as recommended in this [page](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) in Mozilla documentation.

In Chrome CORS policies for extensions is [different](https://www.chromium.org/Home/chromium-security/extension-content-script-fetches), and if I got it right, FAIR-biomed already follows these convention.
